### PR TITLE
Enable default value on (setf (aget ...) ..)

### DIFF
--- a/src/assoc-utils.lisp
+++ b/src/assoc-utils.lisp
@@ -34,7 +34,7 @@
           alist)
         (cons (cons key value) alist))))
 
-(define-setf-expander aget (alist key &environment env)
+(define-setf-expander aget (alist key &optional default &environment env)
   (multiple-value-bind (dummies vals newvals setter getter)
       (get-setf-expansion alist env)
     (let ((newval (first newvals)))
@@ -44,7 +44,7 @@
               `(let ((,newval (%aput ,alist ,key ,newval)))
                  ,setter
                  ,newval)
-              `(aget ,getter ,key)))))
+              `(aget ,getter ,key ,default)))))
 
 (defun remove-from-alist (alist &rest keys)
   (remove-if

--- a/t/assoc-utils.lisp
+++ b/t/assoc-utils.lisp
@@ -22,6 +22,11 @@
     (setf (aget alist "address") "Japan")
     (is (aget alist "address") "Japan")))
 
+(subtest "(incf aget)"
+  (let (alist)
+    (incf (aget alist "value" 0))
+    (is (aget alist "value") 1)))
+
 (subtest "remove-from-alist & delete-from-alist"
   (let ((alist '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com"))))
     (is (remove-from-alist alist "name")

--- a/t/assoc-utils.lisp
+++ b/t/assoc-utils.lisp
@@ -5,7 +5,7 @@
         :prove))
 (in-package :assoc-utils-test)
 
-(plan 8)
+(plan 9)
 
 (subtest "aget"
   (is-error (aget 1 1) 'error)


### PR DESCRIPTION
If key does not exist in alist, use provided default value.
Handy for stuff like (incf (aget alist key 0))