### PR TITLE
Feature: remove alist values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,26 @@ Utilities for manipulating association lists.
 ;=> (("email" . "e.arrows@gmail.com"))
 ```
 
+### remove-values-from-alist & delete-values-from-alist
+
+```common-lisp
+(defparameter *person*
+  '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com")))
+
+(remove-values-from-alist *person* "Eitaro")
+;=> (("email" . "e.arrows@gmail.com"))
+
+*person*
+;=> (("name" . "Eitaro") ("email" . "e.arrows@gmail.com")))
+
+;; Destructive version
+(delete-values-from-alist *person* "e.arrows@gmail.com")
+;=> (("name" . "Eitaro"))
+
+*person*
+;=> (("name" . "Eitaro"))
+```
+
 ### alist-plist & plist-alist
 
 ```common-lisp

--- a/src/assoc-utils.lisp
+++ b/src/assoc-utils.lisp
@@ -7,6 +7,8 @@
            #:remove-from-alistf
            #:delete-from-alist
            #:delete-from-alistf
+           #:remove-values-from-alist
+           #:delete-values-from-alist
            #:alist-plist
            #:plist-alist
            #:alist-hash
@@ -55,6 +57,14 @@
 (define-modify-macro delete-from-alist  (&rest keys) remove-from-alist)
 (define-modify-macro delete-from-alistf (&rest keys) remove-from-alist)
 (define-modify-macro remove-from-alistf (&rest keys) remove-from-alist)
+
+(defun remove-values-from-alist (alist &rest values)
+  (remove-if
+   (lambda (kv)
+     (find (cdr kv) values :test *assoc-test*))
+   alist))
+
+(define-modify-macro delete-values-from-alist (&rest values) remove-values-from-alist)
 
 (defun alist-plist (alist)
   (mapcan (lambda (kv)

--- a/t/assoc-utils.lisp
+++ b/t/assoc-utils.lisp
@@ -5,7 +5,7 @@
         :prove))
 (in-package :assoc-utils-test)
 
-(plan 9)
+(plan 10)
 
 (subtest "aget"
   (is-error (aget 1 1) 'error)
@@ -46,6 +46,15 @@
 
   (let ((alist '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com"))))
     (delete-from-alistf alist "name")
+    (is alist '(("email" . "e.arrows@gmail.com")))))
+
+(subtest "remove-values-from-alist & delete-values-from-alist"
+  (let ((alist '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com"))))
+    (is (remove-values-from-alist alist "Eitaro")
+        '(("email" . "e.arrows@gmail.com")))
+    (is alist '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com"))))
+  (let ((alist '(("name" . "Eitaro") ("email" . "e.arrows@gmail.com"))))
+    (delete-values-from-alist alist "Eitaro")
     (is alist '(("email" . "e.arrows@gmail.com")))))
 
 (subtest "alist-plist & plist-alist"


### PR DESCRIPTION
Added the function `remove-values-from-alist` and modifiy-macro `delete-values-from-alist`, including tests, and documentation.

Alternatively, we could also use the names `remove-alist-values`
and `delete-alist-values`. This would be a bit more concise.
However, I was not sure, if you would like that, since that would be
different naming convention than `remove-from-alist` and `delete-from-alist`.
What you think are the better names?